### PR TITLE
Monitor testing using Scope

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Scope for iOS
-        uses: undefinedlabs/scope-for-ios-action@spm-projects
+        uses: undefinedlabs/scope-for-ios-action@v1
         with:
           dsn: ${{ secrets.SCOPE_DSN }}
           

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Scope Testing
+
+on: [push]
+
+jobs:
+  scope:
+    runs-on: macOS-latest
+    
+    steps:
+      - name: Check if SCOPE_DSN is set
+        run: if [ "${{secrets.SCOPE_DSN}}" = "" ]; then exit 1; fi
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Scope for iOS
+        uses: undefinedlabs/scope-for-ios-action@spm-projects
+        with:
+          dsn: ${{ secrets.SCOPE_DSN }}
+          

--- a/Package_iOS.swift
+++ b/Package_iOS.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.0
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+// The purpose of this file is to disable executable targets and products that fail to compile in iOS.
+// SPM still doesnt support disabling targets per platform.
+// This file will be used as replacement for original Package.swift when built for testing using undefinedlabs/scope-for-ios-action,
+// the replacement is performed automatically by the action
+
+import PackageDescription
+
+let package = Package(
+    name: "opentelemetry-swift",
+    platforms: [.macOS(.v10_12),
+                .iOS(.v10),
+                .tvOS(.v10),
+                .watchOS(.v3)],
+    products: [
+        .library( name: "OpenTelemetryApi", targets: ["OpenTelemetryApi"]),
+        .library( name: "OpenTelemetrySdk", targets: ["OpenTelemetrySdk"]),
+        //.executable(name: "simpleExporter", targets: ["SimpleExporter"]),
+        //.executable(name: "loggingTracer", targets: ["LoggingTracer"]),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        .target(  name: "OpenTelemetryApi", dependencies: []),
+        .target(  name: "OpenTelemetrySdk", dependencies: ["OpenTelemetryApi"]),
+        //.target(  name: "LoggingTracer", dependencies: ["OpenTelemetryApi"], path: "Examples/Logging Tracer"),
+        //.target(  name: "SimpleExporter", dependencies: ["OpenTelemetrySdk"], path: "Examples/Simple Exporter"),
+        .testTarget( name: "OpenTelemetryApiTests", dependencies: ["OpenTelemetryApi"], path: "Tests/OpenTelemetryApiTests"),
+        .testTarget( name: "OpenTelemetrySdkTests", dependencies: ["OpenTelemetryApi", "OpenTelemetrySdk"], path: "Tests/OpenTelemetrySdkTests"),
+    ]
+)

--- a/Package_iOS.swift
+++ b/Package_iOS.swift
@@ -33,3 +33,4 @@ let package = Package(
         .testTarget( name: "OpenTelemetrySdkTests", dependencies: ["OpenTelemetryApi", "OpenTelemetrySdk"], path: "Tests/OpenTelemetrySdkTests"),
     ]
 )
+

--- a/Package_iOS.swift
+++ b/Package_iOS.swift
@@ -33,4 +33,3 @@ let package = Package(
         .testTarget( name: "OpenTelemetrySdkTests", dependencies: ["OpenTelemetryApi", "OpenTelemetrySdk"], path: "Tests/OpenTelemetrySdkTests"),
     ]
 )
-


### PR DESCRIPTION
Use Scope  to monitor testing and track testing history
We will use  [Scope](https://github.com/marketplace/scope-for-github) through [undefinedlabs/scope-for-ios-action](https://github.com/marketplace/scope-for-github)
Add a Package_iOS.swift that will be used by the action (it just comment out executables)
