### PR TITLE
Don't stop the testing done in the action if Scope is not installed 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,8 +7,6 @@ jobs:
     runs-on: macOS-latest
     
     steps:
-      - name: Check if SCOPE_DSN is set
-        run: if [ "${{secrets.SCOPE_DSN}}" = "" ]; then exit 1; fi
       - name: Checkout
         uses: actions/checkout@v1
       - name: Scope for iOS


### PR DESCRIPTION
If the user had not installed Scope, the action would exit before running the tests. Avoid this and run always the the tests, and return the result of this tests for the action